### PR TITLE
Harden admin workflows against CSRF and insecure defaults

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -33,5 +33,6 @@ try {
     $conn->exec("SET NAMES utf8");
 } catch(PDOException $e) {
     // En cas d'erreur de connexion
-    die("Erreur de connexion à la base de données: " . $e->getMessage());
+    logError('Erreur de connexion à la base de données', $e);
+    die("Erreur de connexion à la base de données. Veuillez contacter l'administrateur.");
 }

--- a/export.php
+++ b/export.php
@@ -32,24 +32,24 @@ $success = "";
 $csrfToken = generateCsrfToken();
 
 $allowedExportFields = [
-    'id_personne',
-    'nom',
-    'prenom',
-    'sexe',
-    'age',
-    'date_naissance',
-    'telephone',
-    'email',
-    'etablissement',
-    'statut',
-    'domaine_etudes',
-    'niveau_etudes',
-    'lieu_residence',
-    'type_logement',
-    'precision_logement',
-    'annee_arrivee',
-    'projet_apres_formation',
-    'date_enregistrement'
+    'id_personne' => '`id_personne`',
+    'nom' => '`nom`',
+    'prenom' => '`prenom`',
+    'sexe' => '`sexe`',
+    'age' => '`age`',
+    'date_naissance' => '`date_naissance`',
+    'telephone' => '`telephone`',
+    'email' => '`email`',
+    'etablissement' => '`etablissement`',
+    'statut' => '`statut`',
+    'domaine_etudes' => '`domaine_etudes`',
+    'niveau_etudes' => '`niveau_etudes`',
+    'lieu_residence' => '`lieu_residence`',
+    'type_logement' => '`type_logement`',
+    'precision_logement' => '`precision_logement`',
+    'annee_arrivee' => '`annee_arrivee`',
+    'projet_apres_formation' => '`projet_apres_formation`',
+    'date_enregistrement' => '`date_enregistrement`'
 ];
 
 // Traitement de l'exportation
@@ -62,7 +62,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['export'])) {
 
         $selectedFields = $_POST['fields'] ?? [];
         $selectedFields = array_values(array_unique(array_filter($selectedFields, function ($field) use ($allowedExportFields) {
-            return in_array($field, $allowedExportFields, true);
+            return array_key_exists($field, $allowedExportFields);
         })));
 
         $allowedFilterKeys = ['sexe', 'statut', 'etablissement', 'niveau_etudes', 'type_logement'];
@@ -75,10 +75,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['export'])) {
             $error = "Veuillez sélectionner au moins un champ à exporter.";
         } else {
             try {
-                $escapedFields = array_map(function ($field) {
-                    return "`" . $field . "`";
+                $selectedColumnList = array_map(function ($field) use ($allowedExportFields) {
+                    return $allowedExportFields[$field];
                 }, $selectedFields);
-                $sql = "SELECT " . implode(', ', $escapedFields) . " FROM personne";
+
+                $sql = "SELECT " . implode(', ', $selectedColumnList) . " FROM personne";
 
                 $whereClauses = [];
                 $params = [];

--- a/export.php
+++ b/export.php
@@ -29,118 +29,130 @@ $prenom = $_SESSION['prenom'];
 // Initialiser les variables d'erreur et de succès
 $error = "";
 $success = "";
+$csrfToken = generateCsrfToken();
+
+$allowedExportFields = [
+    'id_personne',
+    'nom',
+    'prenom',
+    'sexe',
+    'age',
+    'date_naissance',
+    'telephone',
+    'email',
+    'etablissement',
+    'statut',
+    'domaine_etudes',
+    'niveau_etudes',
+    'lieu_residence',
+    'type_logement',
+    'precision_logement',
+    'annee_arrivee',
+    'projet_apres_formation',
+    'date_enregistrement'
+];
 
 // Traitement de l'exportation
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['export'])) {
-    // Récupérer les paramètres d'exportation
-    $exportFormat = $_POST['export_format'] ?? 'csv';
-    $selectedFields = $_POST['fields'] ?? [];
-    $filters = [
-        'sexe' => $_POST['sexe'] ?? '',
-        'statut' => $_POST['statut'] ?? '',
-        'etablissement' => $_POST['etablissement'] ?? '',
-        'niveau_etudes' => $_POST['niveau_etudes'] ?? '',
-        'type_logement' => $_POST['type_logement'] ?? ''
-    ];
-
-    // Si aucun champ n'est sélectionné, afficher une erreur
-    if (empty($selectedFields)) {
-        $error = "Veuillez sélectionner au moins un champ à exporter.";
+    if (!verifyCsrfToken($_POST['csrf_token'] ?? '')) {
+        $error = "La session a expiré. Veuillez soumettre à nouveau le formulaire.";
     } else {
-        try {
-            // Construire la requête SQL avec les champs sélectionnés
-            $fields = implode(', ', $selectedFields);
-            $sql = "SELECT $fields FROM personne";
+        $exportFormat = $_POST['export_format'] ?? 'csv';
+        $exportFormat = in_array($exportFormat, ['csv', 'excel', 'json'], true) ? $exportFormat : 'csv';
 
-            // Ajouter les filtres à la requête SQL
-            $whereClauses = [];
-            $params = [];
+        $selectedFields = $_POST['fields'] ?? [];
+        $selectedFields = array_values(array_unique(array_filter($selectedFields, function ($field) use ($allowedExportFields) {
+            return in_array($field, $allowedExportFields, true);
+        })));
 
-            foreach ($filters as $key => $value) {
-                if (!empty($value)) {
-                    $whereClauses[] = "$key = :$key";
-                    $params[":$key"] = $value;
-                }
-            }
+        $allowedFilterKeys = ['sexe', 'statut', 'etablissement', 'niveau_etudes', 'type_logement'];
+        $filters = [];
+        foreach ($allowedFilterKeys as $key) {
+            $filters[$key] = trim($_POST[$key] ?? '');
+        }
 
-            if (count($whereClauses) > 0) {
-                $sql .= " WHERE " . implode(' AND ', $whereClauses);
-            }
+        if (empty($selectedFields)) {
+            $error = "Veuillez sélectionner au moins un champ à exporter.";
+        } else {
+            try {
+                $escapedFields = array_map(function ($field) {
+                    return "`" . $field . "`";
+                }, $selectedFields);
+                $sql = "SELECT " . implode(', ', $escapedFields) . " FROM personne";
 
-            // Exécuter la requête
-            $stmt = $conn->prepare($sql);
-            foreach ($params as $key => $value) {
-                $stmt->bindValue($key, $value);
-            }
-            $stmt->execute();
-            $data = $stmt->fetchAll(PDO::FETCH_ASSOC);
+                $whereClauses = [];
+                $params = [];
 
-            // Si aucune donnée n'est trouvée, afficher un message
-            if (count($data) === 0) {
-                $error = "Aucune donnée ne correspond aux critères sélectionnés.";
-            } else {
-                // Préparer les en-têtes pour l'exportation
-                $headers = array_keys($data[0]);
-
-                // Effectuer l'exportation selon le format choisi
-                if ($exportFormat === 'csv') {
-                    // Exporter au format CSV
-                    $filename = 'export_etudiants_' . date('Y-m-d_H-i-s') . '.csv';
-                    header('Content-Type: text/csv; charset=utf-8');
-                    header('Content-Disposition: attachment; filename="' . $filename . '"');
-
-                    $output = fopen('php://output', 'w');
-
-                    // Ajouter le BOM UTF-8 pour Excel
-                    fprintf($output, chr(0xEF) . chr(0xBB) . chr(0xBF));
-
-                    // Écrire les en-têtes
-                    fputcsv($output, $headers, ';');
-
-                    // Écrire les données
-                    foreach ($data as $row) {
-                        fputcsv($output, $row, ';');
+                foreach ($filters as $key => $value) {
+                    if ($value !== '') {
+                        $whereClauses[] = "$key = :$key";
+                        $params[":$key"] = $value;
                     }
-
-                    fclose($output);
-                    exit();
-                } elseif ($exportFormat === 'excel') {
-                    // Pour l'exportation Excel, nous allons utiliser le format CSV
-                    // car PHP natif ne supporte pas directement l'exportation Excel
-                    // Dans une application réelle, vous pourriez utiliser des bibliothèques comme PhpSpreadsheet
-                    $filename = 'export_etudiants_' . date('Y-m-d_H-i-s') . '.csv';
-                    header('Content-Type: application/vnd.ms-excel; charset=utf-8');
-                    header('Content-Disposition: attachment; filename="' . $filename . '"');
-
-                    $output = fopen('php://output', 'w');
-
-                    // Ajouter le BOM UTF-8 pour Excel
-                    fprintf($output, chr(0xEF) . chr(0xBB) . chr(0xBF));
-
-                    // Écrire les en-têtes
-                    fputcsv($output, $headers, ';');
-
-                    // Écrire les données
-                    foreach ($data as $row) {
-                        fputcsv($output, $row, ';');
-                    }
-
-                    fclose($output);
-                    exit();
-                } elseif ($exportFormat === 'json') {
-                    // Exporter au format JSON
-                    $filename = 'export_etudiants_' . date('Y-m-d_H-i-s') . '.json';
-                    header('Content-Type: application/json; charset=utf-8');
-                    header('Content-Disposition: attachment; filename="' . $filename . '"');
-
-                    echo json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
-                    exit();
                 }
+
+                if (!empty($whereClauses)) {
+                    $sql .= " WHERE " . implode(' AND ', $whereClauses);
+                }
+
+                $stmt = $conn->prepare($sql);
+                foreach ($params as $key => $value) {
+                    $stmt->bindValue($key, $value);
+                }
+                $stmt->execute();
+                $data = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+                if (count($data) === 0) {
+                    $error = "Aucune donnée ne correspond aux critères sélectionnés.";
+                } else {
+                    $headers = array_keys($data[0]);
+
+                    if ($exportFormat === 'csv') {
+                        $filename = 'export_etudiants_' . date('Y-m-d_H-i-s') . '.csv';
+                        header('Content-Type: text/csv; charset=utf-8');
+                        header('Content-Disposition: attachment; filename="' . $filename . '"');
+
+                        $output = fopen('php://output', 'w');
+                        fprintf($output, chr(0xEF) . chr(0xBB) . chr(0xBF));
+                        fputcsv($output, $headers, ';');
+
+                        foreach ($data as $row) {
+                            fputcsv($output, $row, ';');
+                        }
+
+                        fclose($output);
+                        exit();
+                    } elseif ($exportFormat === 'excel') {
+                        $filename = 'export_etudiants_' . date('Y-m-d_H-i-s') . '.csv';
+                        header('Content-Type: application/vnd.ms-excel; charset=utf-8');
+                        header('Content-Disposition: attachment; filename="' . $filename . '"');
+
+                        $output = fopen('php://output', 'w');
+                        fprintf($output, chr(0xEF) . chr(0xBB) . chr(0xBF));
+                        fputcsv($output, $headers, ';');
+
+                        foreach ($data as $row) {
+                            fputcsv($output, $row, ';');
+                        }
+
+                        fclose($output);
+                        exit();
+                    } elseif ($exportFormat === 'json') {
+                        $filename = 'export_etudiants_' . date('Y-m-d_H-i-s') . '.json';
+                        header('Content-Type: application/json; charset=utf-8');
+                        header('Content-Disposition: attachment; filename="' . $filename . '"');
+
+                        echo json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
+                        exit();
+                    }
+                }
+            } catch (PDOException $e) {
+                logError("Erreur lors de l'exportation des données", $e);
+                $error = "Une erreur est survenue lors de l'exportation des données. Veuillez réessayer.";
             }
-        } catch (PDOException $e) {
-            $error = "Erreur lors de l'exportation des données : " . $e->getMessage();
         }
     }
+
+    $csrfToken = generateCsrfToken();
 }
 
 // Récupérer les options pour les filtres
@@ -157,7 +169,8 @@ try {
     $niveauEtudesStmt->execute();
     $niveauxEtudes = $niveauEtudesStmt->fetchAll(PDO::FETCH_COLUMN);
 } catch (PDOException $e) {
-    $error = "Erreur lors de la récupération des options de filtrage : " . $e->getMessage();
+    logError("Erreur lors de la récupération des options de filtrage", $e);
+    $error = "Une erreur est survenue lors de la récupération des options de filtrage.";
 }
 
 // Titre de la page
@@ -227,14 +240,14 @@ $pageTitle = "AEESGS - Exporter les données";
 
                 <?php if (!empty($error)): ?>
                     <div class="alert alert-danger alert-dismissible fade show" role="alert">
-                        <i class="fas fa-exclamation-triangle me-2"></i> <?php echo $error; ?>
+                        <i class="fas fa-exclamation-triangle me-2"></i> <?php echo htmlspecialchars($error); ?>
                         <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
                     </div>
                 <?php endif; ?>
 
                 <?php if (!empty($success)): ?>
                     <div class="alert alert-success alert-dismissible fade show" role="alert">
-                        <i class="fas fa-check-circle me-2"></i> <?php echo $success; ?>
+                        <i class="fas fa-check-circle me-2"></i> <?php echo htmlspecialchars($success); ?>
                         <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
                     </div>
                 <?php endif; ?>
@@ -245,6 +258,7 @@ $pageTitle = "AEESGS - Exporter les données";
                     </div>
                     <div class="card-body">
                         <form method="POST" action="<?php echo htmlspecialchars($_SERVER["PHP_SELF"]); ?>">
+                            <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($csrfToken); ?>">
                             <div class="row mb-4">
                                 <div class="col-lg-6">
                                     <div class="card h-100">

--- a/functions/utility-functions.php
+++ b/functions/utility-functions.php
@@ -148,7 +148,10 @@ function verifyCsrfToken($token) {
 }
 
 /**
- * Journalise une erreur dans le fichier de logs de l'application
+ * Journalise une erreur dans le fichier de logs de l'application.
+ *
+ * Note: Le dossier de logs doit exister et être accessible en écriture. En cas
+ * d'échec de création, l'erreur est reportée dans le journal PHP par défaut.
  *
  * @param string $message Message d'erreur contextuel
  * @param \Throwable|null $exception Exception associée
@@ -158,7 +161,10 @@ function logError($message, ?\Throwable $exception = null) {
     $logDirectory = __DIR__ . '/../storage/logs';
 
     if (!is_dir($logDirectory)) {
-        mkdir($logDirectory, 0775, true);
+        if (!mkdir($logDirectory, 0775, true) && !is_dir($logDirectory)) {
+            error_log("Impossible de créer le dossier de logs: " . $logDirectory);
+            return;
+        }
     }
 
     $logMessage = '[' . date('c') . "] " . $message;

--- a/init-admin.php
+++ b/init-admin.php
@@ -8,8 +8,49 @@
  * puis supprimé du serveur.
  */
 
+// Restreindre l'exécution au mode CLI pour éviter toute exposition via le web
+if (php_sapi_name() !== 'cli') {
+    http_response_code(403);
+    exit('Accès interdit.');
+}
+
 // Inclure la configuration de la base de données
 require_once 'config/database.php';
+require_once 'functions/utility-functions.php';
+
+// Vérifier la présence d'un secret d'exécution pour éviter les exécutions non autorisées
+$expectedSecret = getenv('INIT_ADMIN_SECRET');
+if ($expectedSecret === false || $expectedSecret === '') {
+    echo "La variable d'environnement INIT_ADMIN_SECRET doit être définie pour exécuter ce script." . PHP_EOL;
+    exit(1);
+}
+
+if ($argc < 7) {
+    echo "Utilisation : php init-admin.php <username> <mot_de_passe> <email> <prenom> <nom> <secret>" . PHP_EOL;
+    exit(1);
+}
+
+$username = trim($argv[1]);
+$password = $argv[2];
+$email = trim($argv[3]);
+$prenom = trim($argv[4]);
+$nom = trim($argv[5]);
+$providedSecret = $argv[6];
+
+if (!hash_equals($expectedSecret, $providedSecret)) {
+    echo "Secret d'exécution invalide." . PHP_EOL;
+    exit(1);
+}
+
+if (strlen($password) < 12) {
+    echo "Le mot de passe doit contenir au moins 12 caractères." . PHP_EOL;
+    exit(1);
+}
+
+if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+    echo "L'adresse email fournie n'est pas valide." . PHP_EOL;
+    exit(1);
+}
 
 // Vérifier si un utilisateur administrateur existe déjà
 $checkSql = "SELECT COUNT(*) FROM user WHERE role = 'admin'";
@@ -19,18 +60,12 @@ $adminCount = $checkStmt->fetchColumn();
 
 // Si un administrateur existe déjà, afficher un message et sortir
 if ($adminCount > 0) {
-    echo "Un utilisateur administrateur existe déjà dans la base de données.<br>";
-    echo "Pour des raisons de sécurité, vous ne pouvez pas exécuter ce script à nouveau.<br>";
-    echo "Si vous avez besoin de créer un nouvel administrateur, utilisez l'interface d'administration existante.";
+    echo "Un utilisateur administrateur existe déjà dans la base de données." . PHP_EOL;
+    echo "Veuillez utiliser l'interface d'administration pour gérer les comptes existants." . PHP_EOL;
     exit();
 }
 
-// Informations de l'administrateur par défaut
-$username = "admin";
-$password = "admin123"; // Ce mot de passe devrait être changé après la première connexion
-$nom = "Administrateur";
-$prenom = "AMEA";
-$email = "admin@amea.org";
+// Informations de l'administrateur fourni
 $role = "admin";
 
 // Hacher le mot de passe
@@ -48,25 +83,16 @@ try {
     $stmt->bindParam(':prenom', $prenom);
     $stmt->bindParam(':email', $email);
     $stmt->bindParam(':role', $role);
-    
+
     $stmt->execute();
-    
+
     // Afficher un message de succès
-    echo "<h1>Initialisation réussie</h1>";
-    echo "<p>L'utilisateur administrateur a été créé avec succès.</p>";
-    echo "<p>Nom d'utilisateur: <strong>$username</strong><br>";
-    echo "Mot de passe: <strong>$password</strong></p>";
-    echo "<p>Pour des raisons de sécurité, veuillez :</p>";
-    echo "<ol>";
-    echo "<li>Vous connecter à l'interface d'administration</li>";
-    echo "<li>Changer immédiatement le mot de passe par défaut</li>";
-    echo "<li>Supprimer ce fichier du serveur</li>";
-    echo "</ol>";
-    echo "<p><a href='login.php'>Aller à la page de connexion</a></p>";
-    
+    echo "Initialisation réussie" . PHP_EOL;
+    echo "L'utilisateur administrateur \"$username\" a été créé avec succès." . PHP_EOL;
+    echo "Connectez-vous et supprimez ce script du serveur." . PHP_EOL;
+
 } catch(PDOException $e) {
-    echo "<h1>Erreur</h1>";
-    echo "<p>Une erreur s'est produite lors de la création de l'utilisateur administrateur :</p>";
-    echo "<p>" . $e->getMessage() . "</p>";
+    logError("Erreur lors de l'initialisation de l'administrateur", $e);
+    echo "Une erreur est survenue lors de la création de l'utilisateur administrateur." . PHP_EOL;
 }
 ?>

--- a/login.php
+++ b/login.php
@@ -63,9 +63,9 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
                         // Rediriger vers le tableau de bord
                         header("Location: dashboard.php");
                         exit();
+                    } else {
+                        $error = "Nom d'utilisateur ou mot de passe incorrect.";
                     }
-
-                    $error = "Nom d'utilisateur ou mot de passe incorrect.";
                 } else {
                     $error = "Nom d'utilisateur ou mot de passe incorrect.";
                 }

--- a/login.php
+++ b/login.php
@@ -26,53 +26,53 @@ $csrfToken = generateCsrfToken();
 if ($_SERVER["REQUEST_METHOD"] == "POST") {
     if (!verifyCsrfToken($_POST['csrf_token'] ?? '')) {
         $error = "La session a expiré. Veuillez réessayer.";
-    }
+    } else {
+        $username = trim($_POST['username'] ?? '');
+        $password = $_POST['password'] ?? '';
 
-    $username = trim($_POST['username'] ?? '');
-    $password = $_POST['password'] ?? '';
+        // Validation des entrées
+        if (empty($username) || empty($password)) {
+            $error = "Veuillez entrer un nom d'utilisateur et un mot de passe.";
+        } else {
+            try {
+                // Rechercher l'utilisateur dans la base de données
+                $sql = "SELECT * FROM user WHERE username = :username AND est_actif = 1";
+                $stmt = $conn->prepare($sql);
+                $stmt->bindParam(':username', $username);
+                $stmt->execute();
 
-    // Validation des entrées
-    if (empty($error) && (empty($username) || empty($password))) {
-        $error = "Veuillez entrer un nom d'utilisateur et un mot de passe.";
-    } elseif (empty($error)) {
-        try {
-            // Rechercher l'utilisateur dans la base de données
-            $sql = "SELECT * FROM user WHERE username = :username AND est_actif = 1";
-            $stmt = $conn->prepare($sql);
-            $stmt->bindParam(':username', $username);
-            $stmt->execute();
+                if ($stmt->rowCount() == 1) {
+                    $user = $stmt->fetch(PDO::FETCH_ASSOC);
 
-            if ($stmt->rowCount() == 1) {
-                $user = $stmt->fetch(PDO::FETCH_ASSOC);
+                    // Vérifier le mot de passe
+                    if (password_verify($password, $user['password'])) {
+                        // Connexion réussie, enregistrer les informations dans la session
+                        session_regenerate_id(true);
+                        $_SESSION['user_id'] = $user['id_user'];
+                        $_SESSION['username'] = $user['username'];
+                        $_SESSION['role'] = $user['role'];
+                        $_SESSION['nom'] = $user['nom'];
+                        $_SESSION['prenom'] = $user['prenom'];
 
-                // Vérifier le mot de passe
-                if (password_verify($password, $user['password'])) {
-                    // Connexion réussie, enregistrer les informations dans la session
-                    session_regenerate_id(true);
-                    $_SESSION['user_id'] = $user['id_user'];
-                    $_SESSION['username'] = $user['username'];
-                    $_SESSION['role'] = $user['role'];
-                    $_SESSION['nom'] = $user['nom'];
-                    $_SESSION['prenom'] = $user['prenom'];
+                        // Mettre à jour la dernière connexion
+                        $updateSql = "UPDATE user SET derniere_connexion = NOW() WHERE id_user = :id_user";
+                        $updateStmt = $conn->prepare($updateSql);
+                        $updateStmt->bindParam(':id_user', $user['id_user']);
+                        $updateStmt->execute();
 
-                    // Mettre à jour la dernière connexion
-                    $updateSql = "UPDATE user SET derniere_connexion = NOW() WHERE id_user = :id_user";
-                    $updateStmt = $conn->prepare($updateSql);
-                    $updateStmt->bindParam(':id_user', $user['id_user']);
-                    $updateStmt->execute();
+                        // Rediriger vers le tableau de bord
+                        header("Location: dashboard.php");
+                        exit();
+                    }
 
-                    // Rediriger vers le tableau de bord
-                    header("Location: dashboard.php");
-                    exit();
+                    $error = "Nom d'utilisateur ou mot de passe incorrect.";
                 } else {
                     $error = "Nom d'utilisateur ou mot de passe incorrect.";
                 }
-            } else {
-                $error = "Nom d'utilisateur ou mot de passe incorrect.";
+            } catch (PDOException $e) {
+                logError('Erreur lors de la tentative de connexion', $e);
+                $error = "Une erreur est survenue lors de la tentative de connexion. Veuillez réessayer plus tard.";
             }
-        } catch (PDOException $e) {
-            logError('Erreur lors de la tentative de connexion', $e);
-            $error = "Une erreur est survenue lors de la tentative de connexion. Veuillez réessayer plus tard.";
         }
     }
 

--- a/register.php
+++ b/register.php
@@ -9,13 +9,21 @@
 require_once 'config/database.php';
 require_once 'functions/utility-functions.php';
 
+if (session_status() !== PHP_SESSION_ACTIVE) {
+    session_start();
+}
+
 // Initialiser les variables
-$success = false;
+$successMessage = '';
 $error = "";
 $formData = [];
 
 // Traitement du formulaire lors de la soumission
 if ($_SERVER["REQUEST_METHOD"] == "POST") {
+    if (!verifyCsrfToken($_POST['csrf_token'] ?? '')) {
+        $error = "La session a expiré. Veuillez soumettre à nouveau le formulaire.";
+    }
+
     // Récupérer les données du formulaire
     $formData = [
         'nom' => trim($_POST['nom'] ?? ''),
@@ -51,16 +59,23 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
         'type_logement'
     ];
 
-    foreach ($requiredFields as $field) {
-        if (empty($formData[$field])) {
-            $error = "Tous les champs obligatoires doivent être remplis.";
-            break;
+    if (empty($error)) {
+        foreach ($requiredFields as $field) {
+            if (empty($formData[$field])) {
+                $error = "Tous les champs obligatoires doivent être remplis.";
+                break;
+            }
         }
     }
 
     // Valider l'email
     if (empty($error) && !filter_var($formData['email'], FILTER_VALIDATE_EMAIL)) {
         $error = "L'adresse email n'est pas valide.";
+    }
+
+    // Valider le numéro de téléphone
+    if (empty($error) && !isValidPhone($formData['telephone'])) {
+        $error = "Le numéro de téléphone renseigné n'est pas valide.";
     }
 
     // Calculer l'âge à partir de la date de naissance
@@ -74,41 +89,54 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     // Si aucune erreur, enregistrer les données dans la base de données
     if (empty($error)) {
         try {
-            $sql = "INSERT INTO personne (nom, prenom, sexe, age, date_naissance, lieu_residence, 
-                    etablissement, statut, domaine_etudes, niveau_etudes, telephone, email, 
-                    annee_arrivee, type_logement, precision_logement, projet_apres_formation) 
-                    VALUES (:nom, :prenom, :sexe, :age, :date_naissance, :lieu_residence, 
-                    :etablissement, :statut, :domaine_etudes, :niveau_etudes, :telephone, :email, 
-                    :annee_arrivee, :type_logement, :precision_logement, :projet_apres_formation)";
+            // Vérifier les doublons sur l'adresse email
+            $duplicateSql = "SELECT COUNT(*) FROM personne WHERE email = :email";
+            $duplicateStmt = $conn->prepare($duplicateSql);
+            $duplicateStmt->bindParam(':email', $formData['email']);
+            $duplicateStmt->execute();
 
-            $stmt = $conn->prepare($sql);
-            $stmt->bindParam(':nom', $formData['nom']);
-            $stmt->bindParam(':prenom', $formData['prenom']);
-            $stmt->bindParam(':sexe', $formData['sexe']);
-            $stmt->bindParam(':age', $formData['age']);
-            $stmt->bindParam(':date_naissance', $formData['date_naissance']);
-            $stmt->bindParam(':lieu_residence', $formData['lieu_residence']);
-            $stmt->bindParam(':etablissement', $formData['etablissement']);
-            $stmt->bindParam(':statut', $formData['statut']);
-            $stmt->bindParam(':domaine_etudes', $formData['domaine_etudes']);
-            $stmt->bindParam(':niveau_etudes', $formData['niveau_etudes']);
-            $stmt->bindParam(':telephone', $formData['telephone']);
-            $stmt->bindParam(':email', $formData['email']);
-            $stmt->bindParam(':annee_arrivee', $formData['annee_arrivee']);
-            $stmt->bindParam(':type_logement', $formData['type_logement']);
-            $stmt->bindParam(':precision_logement', $formData['precision_logement']);
-            $stmt->bindParam(':projet_apres_formation', $formData['projet_apres_formation']);
+            if ($duplicateStmt->fetchColumn() > 0) {
+                $error = "Cette adresse email est déjà enregistrée.";
+            } else {
+                $sql = "INSERT INTO personne (nom, prenom, sexe, age, date_naissance, lieu_residence,
+                        etablissement, statut, domaine_etudes, niveau_etudes, telephone, email,
+                        annee_arrivee, type_logement, precision_logement, projet_apres_formation)
+                        VALUES (:nom, :prenom, :sexe, :age, :date_naissance, :lieu_residence,
+                        :etablissement, :statut, :domaine_etudes, :niveau_etudes, :telephone, :email,
+                        :annee_arrivee, :type_logement, :precision_logement, :projet_apres_formation)";
 
-            $stmt->execute();
-            $success = true;
+                $stmt = $conn->prepare($sql);
+                $stmt->bindParam(':nom', $formData['nom']);
+                $stmt->bindParam(':prenom', $formData['prenom']);
+                $stmt->bindParam(':sexe', $formData['sexe']);
+                $stmt->bindParam(':age', $formData['age']);
+                $stmt->bindParam(':date_naissance', $formData['date_naissance']);
+                $stmt->bindParam(':lieu_residence', $formData['lieu_residence']);
+                $stmt->bindParam(':etablissement', $formData['etablissement']);
+                $stmt->bindParam(':statut', $formData['statut']);
+                $stmt->bindParam(':domaine_etudes', $formData['domaine_etudes']);
+                $stmt->bindParam(':niveau_etudes', $formData['niveau_etudes']);
+                $stmt->bindParam(':telephone', $formData['telephone']);
+                $stmt->bindParam(':email', $formData['email']);
+                $stmt->bindParam(':annee_arrivee', $formData['annee_arrivee']);
+                $stmt->bindParam(':type_logement', $formData['type_logement']);
+                $stmt->bindParam(':precision_logement', $formData['precision_logement']);
+                $stmt->bindParam(':projet_apres_formation', $formData['projet_apres_formation']);
 
-            // Réinitialiser les données du formulaire après succès
-            $formData = [];
+                $stmt->execute();
+                $successMessage = "Votre enregistrement a été effectué avec succès ! Merci pour votre participation.";
+
+                // Réinitialiser les données du formulaire après succès
+                $formData = [];
+            }
         } catch (PDOException $e) {
-            $error = "Erreur lors de l'enregistrement: " . $e->getMessage();
+            logError("Erreur lors de l'enregistrement d'un étudiant", $e);
+            $error = "Une erreur inattendue est survenue lors de l'enregistrement. Veuillez réessayer plus tard.";
         }
     }
 }
+
+$csrfToken = generateCsrfToken();
 
 // Titre de la page
 $pageTitle = "AEESGS - Enregistrement";
@@ -319,9 +347,9 @@ $pageTitle = "AEESGS - Enregistrement";
                             <h2 class="h4 mb-0">Formulaire d'enregistrement des étudiants guinéens au Sénégal</h2>
                         </div>
                         <div class="card-body">
-                            <?php if ($success): ?>
+                            <?php if (!empty($successMessage)): ?>
                                 <div class="alert alert-success">
-                                    <i class="fas fa-check-circle"></i> Votre enregistrement a été effectué avec succès ! Merci pour votre participation.
+                                    <i class="fas fa-check-circle"></i> <?php echo htmlspecialchars($successMessage); ?>
                                 </div>
                                 <div class="text-center mb-4">
                                     <a href="register.php" class="btn btn-primary">
@@ -334,13 +362,14 @@ $pageTitle = "AEESGS - Enregistrement";
                             <?php else: ?>
                                 <?php if (!empty($error)): ?>
                                     <div class="alert alert-danger">
-                                        <i class="fas fa-exclamation-triangle"></i> <?php echo $error; ?>
+                                        <i class="fas fa-exclamation-triangle"></i> <?php echo htmlspecialchars($error); ?>
                                     </div>
                                 <?php endif; ?>
 
                                 <p class="text-muted mb-4">Veuillez remplir ce formulaire pour vous enregistrer dans la base de données des étudiants guinéens au Sénégal.</p>
 
                                 <form action="<?php echo htmlspecialchars($_SERVER["PHP_SELF"]); ?>" method="POST" id="registrationForm">
+                                    <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($csrfToken); ?>">
                                     <!-- Informations personnelles -->
                                     <h3 class="h5 mb-3">Informations personnelles</h3>
                                     <div class="row g-3 mb-4">

--- a/register.php
+++ b/register.php
@@ -22,116 +22,114 @@ $formData = [];
 if ($_SERVER["REQUEST_METHOD"] == "POST") {
     if (!verifyCsrfToken($_POST['csrf_token'] ?? '')) {
         $error = "La session a expiré. Veuillez soumettre à nouveau le formulaire.";
-    }
+    } else {
+        // Récupérer les données du formulaire
+        $formData = [
+            'nom' => trim($_POST['nom'] ?? ''),
+            'prenom' => trim($_POST['prenom'] ?? ''),
+            'sexe' => $_POST['sexe'] ?? '',
+            'date_naissance' => $_POST['date_naissance'] ?? '',
+            'lieu_residence' => trim($_POST['lieu_residence'] ?? ''),
+            'etablissement' => trim($_POST['etablissement'] ?? ''),
+            'statut' => $_POST['statut'] ?? '',
+            'domaine_etudes' => trim($_POST['domaine_etudes'] ?? ''),
+            'niveau_etudes' => trim($_POST['niveau_etudes'] ?? ''),
+            'telephone' => trim($_POST['telephone'] ?? ''),
+            'email' => trim($_POST['email'] ?? ''),
+            'annee_arrivee' => $_POST['annee_arrivee'] ?? null,
+            'type_logement' => $_POST['type_logement'] ?? '',
+            'precision_logement' => trim($_POST['precision_logement'] ?? ''),
+            'projet_apres_formation' => trim($_POST['projet_apres_formation'] ?? '')
+        ];
 
-    // Récupérer les données du formulaire
-    $formData = [
-        'nom' => trim($_POST['nom'] ?? ''),
-        'prenom' => trim($_POST['prenom'] ?? ''),
-        'sexe' => $_POST['sexe'] ?? '',
-        'date_naissance' => $_POST['date_naissance'] ?? '',
-        'lieu_residence' => trim($_POST['lieu_residence'] ?? ''),
-        'etablissement' => trim($_POST['etablissement'] ?? ''),
-        'statut' => $_POST['statut'] ?? '',
-        'domaine_etudes' => trim($_POST['domaine_etudes'] ?? ''),
-        'niveau_etudes' => trim($_POST['niveau_etudes'] ?? ''),
-        'telephone' => trim($_POST['telephone'] ?? ''),
-        'email' => trim($_POST['email'] ?? ''),
-        'annee_arrivee' => $_POST['annee_arrivee'] ?? null,
-        'type_logement' => $_POST['type_logement'] ?? '',
-        'precision_logement' => trim($_POST['precision_logement'] ?? ''),
-        'projet_apres_formation' => trim($_POST['projet_apres_formation'] ?? '')
-    ];
+        // Valider les données
+        $requiredFields = [
+            'nom',
+            'prenom',
+            'sexe',
+            'date_naissance',
+            'lieu_residence',
+            'etablissement',
+            'statut',
+            'domaine_etudes',
+            'niveau_etudes',
+            'telephone',
+            'email',
+            'type_logement'
+        ];
 
-    // Valider les données
-    $requiredFields = [
-        'nom',
-        'prenom',
-        'sexe',
-        'date_naissance',
-        'lieu_residence',
-        'etablissement',
-        'statut',
-        'domaine_etudes',
-        'niveau_etudes',
-        'telephone',
-        'email',
-        'type_logement'
-    ];
-
-    if (empty($error)) {
         foreach ($requiredFields as $field) {
             if (empty($formData[$field])) {
                 $error = "Tous les champs obligatoires doivent être remplis.";
                 break;
             }
         }
-    }
 
-    // Valider l'email
-    if (empty($error) && !filter_var($formData['email'], FILTER_VALIDATE_EMAIL)) {
-        $error = "L'adresse email n'est pas valide.";
-    }
+        // Valider l'email
+        if (empty($error) && !filter_var($formData['email'], FILTER_VALIDATE_EMAIL)) {
+            $error = "L'adresse email n'est pas valide.";
+        }
 
-    // Valider le numéro de téléphone
-    if (empty($error) && !isValidPhone($formData['telephone'])) {
-        $error = "Le numéro de téléphone renseigné n'est pas valide.";
-    }
+        // Valider le numéro de téléphone
+        if (empty($error) && !isValidPhone($formData['telephone'])) {
+            $error = "Le numéro de téléphone renseigné n'est pas valide.";
+        }
 
-    // Calculer l'âge à partir de la date de naissance
-    if (empty($error) && !empty($formData['date_naissance'])) {
-        $dateNaissance = new DateTime($formData['date_naissance']);
-        $today = new DateTime();
-        $age = $dateNaissance->diff($today)->y;
-        $formData['age'] = $age;
-    }
+        // Calculer l'âge à partir de la date de naissance
+        if (empty($error) && !empty($formData['date_naissance'])) {
+            $dateNaissance = new DateTime($formData['date_naissance']);
+            $today = new DateTime();
+            $age = $dateNaissance->diff($today)->y;
+            $formData['age'] = $age;
+        }
 
-    // Si aucune erreur, enregistrer les données dans la base de données
-    if (empty($error)) {
-        try {
-            // Vérifier les doublons sur l'adresse email
-            $duplicateSql = "SELECT COUNT(*) FROM personne WHERE email = :email";
-            $duplicateStmt = $conn->prepare($duplicateSql);
-            $duplicateStmt->bindParam(':email', $formData['email']);
-            $duplicateStmt->execute();
+        // Si aucune erreur, enregistrer les données dans la base de données
+        if (empty($error)) {
+            try {
+                // Vérifier les doublons sur l'adresse email
+                $duplicateSql = "SELECT COUNT(*) FROM personne WHERE email = :email";
+                $duplicateStmt = $conn->prepare($duplicateSql);
+                $duplicateStmt->bindParam(':email', $formData['email']);
+                $duplicateStmt->execute();
 
-            if ($duplicateStmt->fetchColumn() > 0) {
-                $error = "Cette adresse email est déjà enregistrée.";
-            } else {
-                $sql = "INSERT INTO personne (nom, prenom, sexe, age, date_naissance, lieu_residence,
-                        etablissement, statut, domaine_etudes, niveau_etudes, telephone, email,
-                        annee_arrivee, type_logement, precision_logement, projet_apres_formation)
-                        VALUES (:nom, :prenom, :sexe, :age, :date_naissance, :lieu_residence,
-                        :etablissement, :statut, :domaine_etudes, :niveau_etudes, :telephone, :email,
-                        :annee_arrivee, :type_logement, :precision_logement, :projet_apres_formation)";
+                if ($duplicateStmt->fetchColumn() > 0) {
+                    $error = "Cette adresse email est déjà enregistrée.";
+                } else {
+                    $sql = "INSERT INTO personne (nom, prenom, sexe, age, date_naissance, lieu_residence,
+                            etablissement, statut, domaine_etudes, niveau_etudes, telephone, email,
+                            annee_arrivee, type_logement, precision_logement, projet_apres_formation)
+                            VALUES (:nom, :prenom, :sexe, :age, :date_naissance, :lieu_residence,
+                            :etablissement, :statut, :domaine_etudes, :niveau_etudes, :telephone, :email,
+                            :annee_arrivee, :type_logement, :precision_logement, :projet_apres_formation)";
 
-                $stmt = $conn->prepare($sql);
-                $stmt->bindParam(':nom', $formData['nom']);
-                $stmt->bindParam(':prenom', $formData['prenom']);
-                $stmt->bindParam(':sexe', $formData['sexe']);
-                $stmt->bindParam(':age', $formData['age']);
-                $stmt->bindParam(':date_naissance', $formData['date_naissance']);
-                $stmt->bindParam(':lieu_residence', $formData['lieu_residence']);
-                $stmt->bindParam(':etablissement', $formData['etablissement']);
-                $stmt->bindParam(':statut', $formData['statut']);
-                $stmt->bindParam(':domaine_etudes', $formData['domaine_etudes']);
-                $stmt->bindParam(':niveau_etudes', $formData['niveau_etudes']);
-                $stmt->bindParam(':telephone', $formData['telephone']);
-                $stmt->bindParam(':email', $formData['email']);
-                $stmt->bindParam(':annee_arrivee', $formData['annee_arrivee']);
-                $stmt->bindParam(':type_logement', $formData['type_logement']);
-                $stmt->bindParam(':precision_logement', $formData['precision_logement']);
-                $stmt->bindParam(':projet_apres_formation', $formData['projet_apres_formation']);
+                    $stmt = $conn->prepare($sql);
+                    $stmt->bindParam(':nom', $formData['nom']);
+                    $stmt->bindParam(':prenom', $formData['prenom']);
+                    $stmt->bindParam(':sexe', $formData['sexe']);
+                    $stmt->bindParam(':age', $formData['age']);
+                    $stmt->bindParam(':date_naissance', $formData['date_naissance']);
+                    $stmt->bindParam(':lieu_residence', $formData['lieu_residence']);
+                    $stmt->bindParam(':etablissement', $formData['etablissement']);
+                    $stmt->bindParam(':statut', $formData['statut']);
+                    $stmt->bindParam(':domaine_etudes', $formData['domaine_etudes']);
+                    $stmt->bindParam(':niveau_etudes', $formData['niveau_etudes']);
+                    $stmt->bindParam(':telephone', $formData['telephone']);
+                    $stmt->bindParam(':email', $formData['email']);
+                    $stmt->bindParam(':annee_arrivee', $formData['annee_arrivee']);
+                    $stmt->bindParam(':type_logement', $formData['type_logement']);
+                    $stmt->bindParam(':precision_logement', $formData['precision_logement']);
+                    $stmt->bindParam(':projet_apres_formation', $formData['projet_apres_formation']);
 
-                $stmt->execute();
-                $successMessage = "Votre enregistrement a été effectué avec succès ! Merci pour votre participation.";
+                    $stmt->execute();
+                    $successMessage = "Votre enregistrement a été effectué avec succès ! Merci pour votre participation.";
 
-                // Réinitialiser les données du formulaire après succès
-                $formData = [];
+                    // Réinitialiser les données du formulaire après succès
+                    $formData = [];
+                }
+            } catch (PDOException $e) {
+                logError("Erreur lors de l'enregistrement d'un étudiant", $e);
+                $error = "Une erreur inattendue est survenue lors de l'enregistrement. Veuillez réessayer plus tard.";
             }
-        } catch (PDOException $e) {
-            logError("Erreur lors de l'enregistrement d'un étudiant", $e);
-            $error = "Une erreur inattendue est survenue lors de l'enregistrement. Veuillez réessayer plus tard.";
         }
     }
 }


### PR DESCRIPTION
## Summary
- enforce reusable CSRF helpers and central error logging while masking PDO connection messages
- protect public and back-office forms with CSRF validation, stricter validation, and sanitized feedback including the users list actions
- lock down the admin bootstrap script to CLI use with a shared secret and document the new process on the login page, while whitelisting export columns

## Testing
- php -l functions/utility-functions.php
- php -l config/database.php
- php -l register.php
- php -l login.php
- php -l users.php
- php -l profile.php
- php -l export.php
- php -l init-admin.php

------
https://chatgpt.com/codex/tasks/task_b_68ed8ed0d09c8322a2acd80cd517e8bb

## Résumé par Sourcery

Renforcer la sécurité de l'application en imposant la protection CSRF, en centralisant la journalisation des erreurs, en nettoyant les entrées/sorties et en limitant l'initialisation de l'administrateur à la CLI avec un secret partagé.

Nouvelles Fonctionnalités :
- Ajout de la génération et de la vérification réutilisables de jetons CSRF appliquées aux formulaires d'exportation, de gestion des utilisateurs, de profil, d'inscription et de connexion.
- Introduction d'un helper `logError` qui écrit des journaux d'exceptions contextuels dans `storage/logs/app.log`.
- Extension de la fonctionnalité d'exportation pour inclure la sortie JSON et imposer une liste blanche de champs exportables.
- Restriction de `init-admin.php` à l'exécution CLI avec un secret partagé requis et documentation de son utilisation sur la page de connexion.

Améliorations :
- Nettoyage de toutes les sorties dynamiques avec `htmlspecialchars` ou `secureData` et application d'un transtypage strict sur les identifiants et les entrées de formulaire.
- Conversion des actions de suppression d'utilisateur, de bascule de statut et de réinitialisation de mot de passe en formulaires POST protégés par CSRF.
- Renforcement de la validation des entrées pour les numéros de téléphone, les e-mails et les champs de formulaire, et masquage des erreurs brutes de base de données.
- Masquage des détails d'échec de connexion à la base de données et application de l'UTF-8 dans la configuration de la base de données.

Documentation :
- Mise à jour de la page de connexion de l'administrateur pour expliquer le nouveau processus d'initialisation de l'administrateur basé sur la CLI.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden security across the application by enforcing CSRF protection, centralizing error logging, sanitizing inputs/outputs, and locking down admin initialization to the CLI with a shared secret.

New Features:
- Add reusable CSRF token generation and verification applied to export, user management, profile, registration, and login forms.
- Introduce a logError helper that writes contextual exception logs to storage/logs/app.log.
- Extend export functionality to include JSON output and enforce a whitelist of exportable fields.
- Restrict init-admin.php to CLI execution with a required shared secret and document its usage on the login page.

Enhancements:
- Sanitize all dynamic output with htmlspecialchars or secureData and enforce strict type casting on IDs and form inputs.
- Convert user deletion, status toggling, and password reset actions to CSRF-protected POST forms.
- Strengthen input validation for phone numbers, emails, and form fields and mask raw database errors.
- Mask database connection failure details and enforce UTF-8 in the database config.

Documentation:
- Update the admin login page to explain the new CLI-based administrator initialization process.

</details>